### PR TITLE
Use regex from fbp grammar to match port names

### DIFF
--- a/syntax/fbp.vim
+++ b/syntax/fbp.vim
@@ -18,16 +18,16 @@ syn match fbpComment /#.*/ contains=fbpTodo
 hi def link fbpComment Comment
 
 " edges
-syn match fbpEdge /\<\u\+\s*->\s*\u\+\>/ contains=fbpOUT,fbpIN
+syn match fbpEdge /\<[a-zA-Z_][a-zA-Z0-9_\-]\+\s*->\s*[a-zA-Z_][a-zA-Z0-9_\-]\+\>/ contains=fbpOUT,fbpIN
 hi fbpEdge ctermfg=green cterm=bold guifg=#859900 gui=bold
 
 syn match fbpArrow /->/ contained
 hi def link fbpArrow Operator
 
-syn match fbpOUT /\<\u\+\s*->/ contained contains=fbpArrow
+syn match fbpOUT /\<[a-zA-Z_][a-zA-Z0-9_\-]\+\s*->/ contained contains=fbpArrow
 hi def link fbpOUT Type
 
-syn match fbpIN  /->\s*\u\+\>/ contains=fbpArrow
+syn match fbpIN  /->\s*[a-zA-Z_][a-zA-Z0-9_\-]\+\>/ contains=fbpArrow
 hi fbpIN ctermfg=green cterm=bold guifg=#859900 gui=bold
 
 " components


### PR DESCRIPTION
This PR allows underscores, dashes, and lowercase letters in port names. Regex is taken directly from fbp grammar: https://github.com/ifitzpatrick/fbp/blob/master/grammar/fbp.peg#L194

~~Lowercase is not yet supported in the main repo, but I am working with them to make port names case sensitive. I would be willing to take that out of this pull request to get it merged in if you prefer.~~

Case sensitivity is now merged into both flowbased/fbp and noflo/noflo repositories.
